### PR TITLE
Add option for JSON output to lv2-grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ repository or from source.
 
 Print URIs of all installed LV2 plugins matching the given regular expression.
 
+Can optionally output the list of matching plugins in JSON format, where each
+list item is an object with the plugin name and uri and optionally the list of
+categories the plugin belongs to, as properties.
+
 
 ### `lv2-plugin-uris`
 


### PR DESCRIPTION
Implements FR #1.

Also adds an option to add a list of categories o f each plugin to the JSON output.

Lastly, the pattern is now optional, if no pattern is given on the command line, all installed plugins are listed.